### PR TITLE
Added the TIP for FTS Limit cap and preview/HEAD.yml file

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -36,6 +36,19 @@ All simple query types are created in the same manner.
 Some have additional properties, which can be seen in common query type descriptions.
 Couchbase FTS's xref:{version-server}@server:fts:fts-query-types.adoc[range of query types] enable powerful searching using multiple options, to ensure results are just within the range wanted.
 
+
+[TIP]
+.Search Results Limit
+====
+By default, the Search Service returns only the first 10 matches (`size: 10`, `from: 0`).
+To retrieve more results, you must explicitly define pagination settings such as `size` or `from` in your query.
+
+For information about formatting your Search query and specifying limits, see xref:server:search:search-request-params.adoc[].
+
+For information about pagination in Search responses, see xref:server:fts:fts-search-response.adoc#pagination[Pagination].
+====
+
+
 == Working with Results
 
 The result of a search query has three components: rows, facets, and metadata.

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
[DOC-14075](https://jira.issues.couchbase.com/browse/DOC-14075)

Added a TIP about the FTS search results limit. Added a couple of hyperlinks pointing to docs that reside in the docs-server and docs-devex repos.
Also added the directory and yml file, preview/HEAD.yml, since the docs-sdk-rust repo did not have them.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-rust-DOC-14075_Rust_FTS_Limits_Cap/rust-sdk/current/howtos/full-text-searching-with-sdk.html)

[DOC-14075]: https://couchbasecloud.atlassian.net/browse/DOC-14075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ